### PR TITLE
fix(db): preserve PostgreSQL dialect-specific types during export

### DIFF
--- a/src/db/src/adapters/type_mapping/postgres_mapper.rs
+++ b/src/db/src/adapters/type_mapping/postgres_mapper.rs
@@ -972,6 +972,23 @@ mod tests {
     }
 
     #[test]
+    fn test_postgres_parse_macaddr8() {
+        let mapper = PostgresTypeMapper;
+        let meta = TypeMetadata {
+            udt_name: Some("macaddr8".to_string()),
+            enum_names: Some(HashSet::new()),
+            ..Default::default()
+        };
+        let result = mapper.parse_sql_type("USER-DEFINED", &meta).unwrap();
+        match result {
+            ColumnType::DialectSpecific { kind, .. } => {
+                assert_eq!(kind, "MACADDR8");
+            }
+            _ => panic!("Expected DialectSpecific MACADDR8 type, got {:?}", result),
+        }
+    }
+
+    #[test]
     fn test_postgres_inet_roundtrip() {
         let service = TypeMappingService::new(Dialect::PostgreSQL);
         let meta = TypeMetadata {
@@ -1016,5 +1033,31 @@ mod tests {
         let parsed = service.from_sql_type("bit varying", &meta).unwrap();
         let sql = service.to_sql_type(&parsed);
         assert_eq!(sql, "VARBIT");
+    }
+
+    #[test]
+    fn test_postgres_macaddr_roundtrip() {
+        let service = TypeMappingService::new(Dialect::PostgreSQL);
+        let meta = TypeMetadata {
+            udt_name: Some("macaddr".to_string()),
+            enum_names: Some(HashSet::new()),
+            ..Default::default()
+        };
+        let parsed = service.from_sql_type("USER-DEFINED", &meta).unwrap();
+        let sql = service.to_sql_type(&parsed);
+        assert_eq!(sql, "MACADDR");
+    }
+
+    #[test]
+    fn test_postgres_macaddr8_roundtrip() {
+        let service = TypeMappingService::new(Dialect::PostgreSQL);
+        let meta = TypeMetadata {
+            udt_name: Some("macaddr8".to_string()),
+            enum_names: Some(HashSet::new()),
+            ..Default::default()
+        };
+        let parsed = service.from_sql_type("USER-DEFINED", &meta).unwrap();
+        let sql = service.to_sql_type(&parsed);
+        assert_eq!(sql, "MACADDR8");
     }
 }


### PR DESCRIPTION
## Summary

PostgreSQL dialect-specific types (INET, CIDR, VARBIT) were incorrectly converted to TEXT during `strata export`. This broke round-trip compatibility — exporting a schema and using it as the source for `generate` produced false diffs.

**Root cause**: `PostgresTypeMapper::parse_sql_type` did not handle these types:
- **VARBIT**: PostgreSQL reports it as `data_type = "bit varying"`, which fell through to the `_ => None` catch-all
- **INET/CIDR**: PostgreSQL reports these as `data_type = "USER-DEFINED"` with `udt_name = "inet"/"cidr"`, but the `USER-DEFINED` branch only checked for ENUM types

**Fix**: Added handling for:
- `"bit varying"` → `DialectSpecific { kind: "VARBIT", length: N }`
- `"USER-DEFINED"` with known udt_names (inet, cidr, macaddr, macaddr8) → `DialectSpecific` with the appropriate type name

## Related Issue

Fixes #23

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or tooling changes

## Test Plan

- [x] Added/updated unit tests
- [ ] Tested manually with PostgreSQL
- [ ] Tested manually with MySQL
- [ ] Tested manually with SQLite

Added 10 regression tests covering:
- Parse tests for INET, CIDR, VARBIT (with/without length), MACADDR
- Round-trip tests verifying `from_sql_type` → `to_sql_type` produces correct SQL for each type

## Checklist

- [x] My code follows the project's coding style
- [x] I have run `cargo fmt` and `cargo clippy`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`cargo test`)
- [ ] I have updated documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recognition, parsing, and round-trip preservation for PostgreSQL-specific types (INET, CIDR, MACADDR, MACADDR8, VARBIT) and improved VARBIT formatting with optional length. Dialect-specific ARRAY formatting now includes element-type handling.

* **Tests**
  * Expanded tests covering parsing, formatting, and round-trip behavior for the new PostgreSQL-specific types, ARRAY interactions, and unmapped/unknown cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->